### PR TITLE
fix vercel config for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,20 +6,22 @@
     },
     {
       "src": "frontend/package.json",
-      "use": "@vercel/static-build"
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
     }
   ],
   "routes": [
     {
       "src": "/api/(.*)",
-      "dest": "api/index.py"
+      "dest": "/api/index.py"
     },
     {
-      "src": "/",
-      "dest": "/frontend/dist/index.html"
+      "handle": "filesystem"
     },
     {
-      "src": "/(.*)",
+      "src": "/.*",
       "dest": "/frontend/dist/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- configure Vercel static build output
- ensure frontend assets served before SPA fallback

## Testing
- `npm run build`
- `python -m py_compile index.py`


------
https://chatgpt.com/codex/tasks/task_e_68c18e8f5e4c832785c99703e3738e90